### PR TITLE
feat: add `page.setContent`

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -233,6 +233,27 @@ export class Page extends EventTarget {
   }
 
   /**
+   * Set page content
+   */
+  async setContent(content: string): Promise<void> {
+    await this.evaluate(
+      (html) => {
+        const { document } = globalThis as unknown as {
+          document: {
+            open: () => void;
+            write: (html: string) => void;
+            close: () => void;
+          };
+        };
+        document.open();
+        document.write(html);
+        document.close();
+      },
+      { args: [content] },
+    );
+  }
+
+  /**
    * If no URLs are specified, this method returns cookies for the current page URL. If URLs are specified, only cookies for those URLs are returned.
    */
   async cookies(...urls: string[]): Promise<Cookie[]> {

--- a/tests/set_content_test.ts
+++ b/tests/set_content_test.ts
@@ -1,0 +1,32 @@
+import { assertStrictEquals } from "https://deno.land/std@0.201.0/assert/assert_strict_equals.ts";
+import { launch } from "../mod.ts";
+
+Deno.test("Set content", async () => {
+  // Launch browser
+  const browser = await launch();
+  const content = `
+  <!DOCTYPE html>
+  <html>
+    <head>
+      <title>Astral</title>
+    </head>
+    <body>
+      <span>Hello world</span>
+    </body>
+  </html>`;
+
+  // Open the webpage and set content
+  const page = await browser.newPage();
+  await page.setContent(content);
+
+  // Wait for selector
+  assertStrictEquals(
+    content.replace(/\s/g, ""),
+    `${await page.content()}`.replace(/\s/g, ""),
+  );
+  const selected = await page.waitForSelector("span");
+  assertStrictEquals(await selected.innerText(), "Hello world");
+
+  // Close browser
+  await browser.close();
+});


### PR DESCRIPTION
Implement `page.setContent()` method
Mostly ported from 
https://github.com/puppeteer/puppeteer/blob/067a5b290083adcb297231ed360cec27ce2e4155/packages/puppeteer-core/src/common/util.ts#L554-L565