### PR TITLE
fix: don't crash if chrome singletonlock is already removed after detection

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -33,7 +33,13 @@ async function runCommand(
       process.kill();
       await process.status;
 
-      Deno.removeSync(path);
+      try {
+        Deno.removeSync(path);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) {
+          throw error;
+        }
+      }
       return runCommand(command);
     }
   }


### PR DESCRIPTION
The singleton lock of chrome may already been removed during the time the message was receive and the process closing.
This prevents dying if it was already cleaned before astral has the time to do it