### PR TITLE
fix: don't require --allow-env perms when cache param is specified

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -180,6 +180,7 @@ export interface LaunchOptions {
   product?: "chrome" | "firefox";
   args?: string[];
   wsEndpoint?: string;
+  cache?: string;
 }
 
 /**
@@ -190,6 +191,7 @@ export async function launch(opts?: LaunchOptions) {
   const product = opts?.product ?? "chrome";
   const args = opts?.args ?? [];
   const wsEndpoint = opts?.wsEndpoint;
+  const cache = opts?.cache;
   let path = opts?.path;
 
   const options: BrowserOptions = {
@@ -205,7 +207,7 @@ export async function launch(opts?: LaunchOptions) {
   }
 
   if (!path) {
-    path = await getBinary(product);
+    path = await getBinary(product, { cache });
   }
 
   // Launch child process

--- a/tests/get_binary_test.ts
+++ b/tests/get_binary_test.ts
@@ -20,7 +20,6 @@ const permissions = {
   ],
   read: [cache],
   net: true,
-  env: true,
   run: true,
 };
 


### PR DESCRIPTION
Small patch to avoid requiring `--allow-env` permissions (which is used to compute default cache path) when a cache path is manually specified by end user