### PR TITLE
feat: support sandbox mode

### DIFF
--- a/docs/pages/advanced/sandbox.md
+++ b/docs/pages/advanced/sandbox.md
@@ -14,23 +14,29 @@ validate network requests (using `--allow-net` permissions) and file requests
 ```ts
 // Import Astral
 import { launch } from "https://deno.land/x/astral/mod.ts";
+import { fromFileUrl } from "https://deno.land/std/path/from_file_url.ts";
 
 // Launch browser
 const browser = await launch({});
 
 // Open the page if permission granted, or throws Deno.errors.PermissionDenied
-const { state } = await Deno.permissions.query({
-  name: "net",
-  path: "example.com",
-});
-await browser.newPage("https://example.com", { sandbox: true });
+{
+  const { state } = await Deno.permissions.query({
+    name: "net",
+    path: "example.com",
+  });
+  await browser.newPage("https://example.com", { sandbox: true });
+}
+
+// Open the page if permission granted, or throws Deno.errors.PermissionDenied
+{
+  const { state } = await Deno.permissions.query({
+    name: "read",
+    path: fromFileUrl(import.meta.url),
+  });
+  await browser.newPage(fromFileUrl(import.meta.url), { sandbox: true });
+}
 
 // Close browser
 await browser.close();
 ```
-
-Deno.test("Sandbox reject denied read permissions", { permissions: {
-...permissions, net: ["127.0.0.1"] }, }, async () => { const browser = await
-launch();
-
-assertStrictEquals(await page.evaluate(status), 0); await browser.close(); });

--- a/docs/pages/advanced/sandbox.md
+++ b/docs/pages/advanced/sandbox.md
@@ -1,6 +1,6 @@
 ---
-title: Connect to existing browser
-description: How to connect an existing browser process with astral
+title: Sandbox permissions
+description: How to use Deno permissions to sandbox pages
 index: 4
 ---
 

--- a/docs/pages/advanced/sandbox.md
+++ b/docs/pages/advanced/sandbox.md
@@ -1,0 +1,36 @@
+---
+title: Connect to existing browser
+description: How to connect an existing browser process with astral
+index: 4
+---
+
+`Browser.newPage()` supports a `sandbox` mode, which use
+[Deno permissions](https://docs.deno.com/runtime/manual/basics/permissions) to
+validate network requests (using `--allow-net` permissions) and file requests
+(using `--allow-read` permissions) on the opened page.
+
+## Code
+
+```ts
+// Import Astral
+import { launch } from "https://deno.land/x/astral/mod.ts";
+
+// Launch browser
+const browser = await launch({});
+
+// Open the page if permission granted, or throws Deno.errors.PermissionDenied
+const { state } = await Deno.permissions.query({
+  name: "net",
+  path: "example.com",
+});
+await browser.newPage("https://example.com", { sandbox: true });
+
+// Close browser
+await browser.close();
+```
+
+Deno.test("Sandbox reject denied read permissions", { permissions: {
+...permissions, net: ["127.0.0.1"] }, }, async () => { const browser = await
+launch();
+
+assertStrictEquals(await page.evaluate(status), 0); await browser.close(); });

--- a/docs/pages/advanced/sandbox.md
+++ b/docs/pages/advanced/sandbox.md
@@ -17,7 +17,7 @@ import { launch } from "https://deno.land/x/astral/mod.ts";
 import { fromFileUrl } from "https://deno.land/std/path/from_file_url.ts";
 
 // Launch browser
-const browser = await launch({});
+const browser = await launch();
 
 // Open the page if permission granted, or throws Deno.errors.PermissionDenied
 {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -138,6 +138,7 @@ export class Browser {
       }),
       celestial.Page.enable(),
       celestial.Page.setInterceptFileChooserDialog({ enabled: true }),
+      sandbox ? celestial.Fetch.enable({}) : null,
     ]);
 
     if (url) {

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -122,11 +122,8 @@ export class Browser {
     const websocket = new WebSocket(wsUrl);
     await websocketReady(websocket);
 
-    const { waitUntil, sandbox, sandboxPrompt } = options ?? {};
-    const page = new Page(targetId, url, websocket, this, {
-      sandbox,
-      sandboxPrompt,
-    });
+    const { waitUntil, sandbox } = options ?? {};
+    const page = new Page(targetId, url, websocket, this, { sandbox });
     this.pages.push(page);
 
     const celestial = page.unsafelyGetCelestialBindings();

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -2,7 +2,7 @@ import { retry } from "https://deno.land/std@0.201.0/async/retry.ts";
 
 import { Celestial, PROTOCOL_VERSION } from "../bindings/celestial.ts";
 import { getBinary } from "./cache.ts";
-import { Page, WaitForOptions } from "./page.ts";
+import { Page, SandboxOptions, WaitForOptions } from "./page.ts";
 import { WEBSOCKET_ENDPOINT_REGEX, websocketReady } from "./util.ts";
 
 async function runCommand(
@@ -112,7 +112,7 @@ export class Browser {
   /**
    * Promise which resolves to a new `Page` object.
    */
-  async newPage(url?: string, options?: WaitForOptions) {
+  async newPage(url?: string, options?: WaitForOptions & SandboxOptions) {
     const { targetId } = await this.#celestial.Target.createTarget({
       url: "",
     });
@@ -122,7 +122,11 @@ export class Browser {
     const websocket = new WebSocket(wsUrl);
     await websocketReady(websocket);
 
-    const page = new Page(targetId, url, websocket, this);
+    const { waitUntil, sandbox, sandboxPrompt } = options ?? {};
+    const page = new Page(targetId, url, websocket, this, {
+      sandbox,
+      sandboxPrompt,
+    });
     this.pages.push(page);
 
     const celestial = page.unsafelyGetCelestialBindings();
@@ -137,7 +141,7 @@ export class Browser {
     ]);
 
     if (url) {
-      await page.goto(url, options);
+      await page.goto(url, { waitUntil });
     }
 
     return page;

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -38,7 +38,7 @@ async function knownGoodVersions(): Promise<KnownGoodVersions> {
   return await req.json();
 }
 
-function getDefaultCachePath() {
+export function getDefaultCachePath() {
   const HOME_PATH = Deno.build.os === "windows"
     ? Deno.env.get("USERPROFILE")!
     : Deno.env.get("HOME")!;

--- a/src/page.ts
+++ b/src/page.ts
@@ -94,7 +94,7 @@ export class Page extends EventTarget {
     url: string | undefined,
     ws: WebSocket,
     browser: Browser,
-    options?: SandboxOptions,
+    options: SandboxOptions,
   ) {
     super();
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,6 +1,6 @@
 import { deadline } from "https://deno.land/std@0.201.0/async/deadline.ts";
 
-import {
+import type {
   Celestial,
   Network_Cookie,
   Network_ResourceType,

--- a/src/page.ts
+++ b/src/page.ts
@@ -13,6 +13,7 @@ import { Keyboard } from "./keyboard.ts";
 import { Touchscreen } from "./touchscreen.ts";
 import { Dialog } from "./dialog.ts";
 import { FileChooser } from "./file_chooser.ts";
+import { fromFileUrl } from "https://deno.land/std@0.201.0/path/from_file_url.ts";
 
 export type DeleteCookieOptions = Omit<
   Parameters<Celestial["Network"]["deleteCookies"]>[0],
@@ -143,12 +144,13 @@ export class Page extends EventTarget {
 
   //TODO(@lowlighter): change "query" by "request" https://github.com/denoland/deno/issues/14668
   async #validateRequest({ request }: Fetch_requestPausedEvent["detail"]) {
-    const { protocol, host, pathname: path } = new URL(request.url);
+    const { protocol, host, href } = new URL(request.url);
     if (host) {
       const { state } = await Deno.permissions.query({ name: "net", host });
       return (state === "granted");
     }
     if (protocol === "file:") {
+      const path = fromFileUrl(href);
       const { state } = await Deno.permissions.query({ name: "read", path });
       return (state === "granted");
     }

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,7 +1,7 @@
 import { deadline } from "https://deno.land/std@0.201.0/async/deadline.ts";
 
+import { Celestial } from "../bindings/celestial.ts";
 import type {
-  Celestial,
   Network_Cookie,
   Network_ResourceType,
 } from "../bindings/celestial.ts";
@@ -126,7 +126,6 @@ export class Page extends EventTarget {
 
     if (options?.sandbox) {
       const { sandbox, sandboxPrompt } = options;
-      this.#celestial.Fetch.enable({});
       this.#celestial.addEventListener("Fetch.requestPaused", async (e) => {
         const { request, requestId, resourceType } = e.detail;
         if (

--- a/tests/get_binary_test.ts
+++ b/tests/get_binary_test.ts
@@ -18,6 +18,7 @@ const permissions = {
       Deno.env.get("HOME")
     }/Library/Application Support/Chromium/SingletonLock`,
   ],
+  env: ["CI", "ASTRAL_QUIET_INSTALL"],
   read: [cache],
   net: true,
   run: true,

--- a/tests/sandbox_test.ts
+++ b/tests/sandbox_test.ts
@@ -27,7 +27,7 @@ Deno.test("Sandbox reject denied net permissions", {
   await browser.close();
 });
 
-Deno.test("Sandbox fulfill granted read permissions", {
+Deno.test.ignore("Sandbox fulfill granted read permissions", {
   permissions: {
     ...permissions,
     read: [...permissions.read, fromFileUrl(import.meta.url)],

--- a/tests/sandbox_test.ts
+++ b/tests/sandbox_test.ts
@@ -1,0 +1,41 @@
+import { launch } from "../mod.ts";
+import { assertStrictEquals } from "https://deno.land/std@0.201.0/assert/assert_strict_equals.ts";
+import { assert } from "https://deno.land/std@0.201.0/assert/assert.ts";
+
+const permissions = { read: true, write: true, run: true, env: true };
+const status =
+  "window.performance.getEntriesByType('navigation')[0].responseStatus";
+
+Deno.test("Sandbox allow granted permissions", {
+  permissions: { ...permissions, net: ["127.0.0.1", "example.com"] },
+}, async () => {
+  const browser = await launch();
+  const page = await browser.newPage("http://example.com", { sandbox: true });
+  assertStrictEquals(await page.evaluate(status), 200);
+  await browser.close();
+});
+
+Deno.test("Sandbox refuse denied permissions", {
+  permissions: { ...permissions, net: ["127.0.0.1"] },
+}, async () => {
+  const browser = await launch();
+  const page = await browser.newPage("http://example.com", { sandbox: true });
+  assertStrictEquals(await page.evaluate(status), 0);
+  await browser.close();
+});
+
+Deno.test("Sandbox trying to redirect or fetch with denied permissions fails", {
+  permissions: { ...permissions, net: ["127.0.0.1", "example.com"] },
+}, async () => {
+  const browser = await launch();
+  const page = await browser.newPage("http://example.com", { sandbox: true });
+  assertStrictEquals(await page.evaluate(status), 200);
+  await page.evaluate("location = 'http://google.com'");
+  assertStrictEquals(await page.evaluate(status), 0);
+  assert(
+    await page.evaluate(
+      "fetch('https://deno.land').then(() => false).catch(() => true)",
+    ),
+  );
+  await browser.close();
+});

--- a/tests/sandbox_test.ts
+++ b/tests/sandbox_test.ts
@@ -1,12 +1,15 @@
-import { launch } from "../mod.ts";
+import { getDefaultCachePath, launch } from "../mod.ts";
 import { assertStrictEquals } from "https://deno.land/std@0.201.0/assert/assert_strict_equals.ts";
 import { assert } from "https://deno.land/std@0.201.0/assert/assert.ts";
+import { fromFileUrl } from "https://deno.land/std@0.201.0/path/from_file_url.ts";
 
-const permissions = { read: true, write: true, run: true, env: true };
+const cache = getDefaultCachePath();
+
+const permissions = { read: [cache], write: true, run: true, env: true };
 const status =
   "window.performance.getEntriesByType('navigation')[0].responseStatus";
 
-Deno.test("Sandbox allow granted permissions", {
+Deno.test("Sandbox fulfill granted net permissions", {
   permissions: { ...permissions, net: ["127.0.0.1", "example.com"] },
 }, async () => {
   const browser = await launch();
@@ -15,7 +18,7 @@ Deno.test("Sandbox allow granted permissions", {
   await browser.close();
 });
 
-Deno.test("Sandbox refuse denied permissions", {
+Deno.test("Sandbox reject denied net permissions", {
   permissions: { ...permissions, net: ["127.0.0.1"] },
 }, async () => {
   const browser = await launch();
@@ -24,7 +27,29 @@ Deno.test("Sandbox refuse denied permissions", {
   await browser.close();
 });
 
-Deno.test("Sandbox trying to redirect or fetch with denied permissions fails", {
+Deno.test("Sandbox fulfill granted read permissions", {
+  permissions: {
+    ...permissions,
+    read: [...permissions.read, fromFileUrl(import.meta.url)],
+    net: ["127.0.0.1"],
+  },
+}, async () => {
+  const browser = await launch();
+  const page = await browser.newPage(import.meta.url, { sandbox: true });
+  assertStrictEquals(await page.evaluate(status), 200);
+  await browser.close();
+});
+
+Deno.test("Sandbox reject denied read permissions", {
+  permissions: { ...permissions, net: ["127.0.0.1"] },
+}, async () => {
+  const browser = await launch();
+  const page = await browser.newPage(import.meta.url, { sandbox: true });
+  assertStrictEquals(await page.evaluate(status), 0);
+  await browser.close();
+});
+
+Deno.test("Sandbox cannot be escaped with redirects or scripts", {
   permissions: { ...permissions, net: ["127.0.0.1", "example.com"] },
 }, async () => {
   const browser = await launch();

--- a/tests/sandbox_test.ts
+++ b/tests/sandbox_test.ts
@@ -27,7 +27,7 @@ Deno.test("Sandbox reject denied net permissions", {
   await browser.close();
 });
 
-Deno.test.ignore("Sandbox fulfill granted read permissions", {
+Deno.test("Sandbox fulfill granted read permissions", {
   permissions: {
     ...permissions,
     read: [...permissions.read, fromFileUrl(import.meta.url)],


### PR DESCRIPTION
Towards #33

This adds a `sandbox` parameters to `browser.newPage()`:

- If `sandbox: true`, each network request is intercepted and checked against deno permissions
- If `sandbox: Network_ResourceType[]`, only network requests matching the resource type are intercepted and checked against deno permissions (for example, you can choose to just sandbox `document` or `fetch`  request)

Unfortunately because of https://github.com/denoland/deno/issues/14668, I had to add a `sandboxPrompt` arg to toggle interactivity, since the current `Deno.permissions.request` will always ask for permissions even when passing `--no-prompt` or with `DENO_NO_PROMPT=1`

From the unit test I added, it seems pretty robuts, as you even if you try to use `page.evaluate` to redirect or fetch with JS, the network request will be intercepted (provided you pass the correct resource type in sandbox)

Small demo:
![ezgif-1-3ad9a18719](https://github.com/lino-levan/astral/assets/22963968/be5f70e3-3bfc-4f78-87be-23c9e38d45d2)


Side notes:
- For the tests, I use `window.performance.getEntriesByType('navigation')[0].responseStatus` which returns the status code of the page. When using `#celestial.Fetch.failRequest` the response status will be `0` **however** the page is not empty, from I've seen it display a chrome error page telling that the request failed.
- Additional thoughts: should `file://` protocol use `--allow-read` permissions instead and supported by this feature ?