### PR TITLE
chore: enhancement waitForSelector method

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@astral/astral",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "exports": "./mod.ts",
   "tasks": {
     // The task to automatically generate `./src/celestial.ts`

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@astral/astral",
-  "version": "0.3.5",
+  "version": "0.3.4",
   "exports": "./mod.ts",
   "tasks": {
     // The task to automatically generate `./src/celestial.ts`

--- a/src/element_handle.ts
+++ b/src/element_handle.ts
@@ -2,7 +2,7 @@ import { deadline } from "https://deno.land/std@0.205.0/async/deadline.ts";
 
 import { Celestial, type Runtime_CallArgument } from "../bindings/celestial.ts";
 import { KeyboardTypeOptions } from "./keyboard.ts";
-import { Page, ScreenshotOptions } from "./page.ts";
+import { Page, ScreenshotOptions, WaitForSelectorOptions } from "./page.ts";
 import { retryDeadline } from "./util.ts";
 
 export interface Offset {
@@ -305,25 +305,29 @@ export class ElementHandle {
   /**
    * Wait for an element matching the given selector to appear in the current element.
    */
-  async waitForSelector(selector: string) {
+  async waitForSelector(selector: string, options?: WaitForSelectorOptions) {
     // TODO(lino-levan): Make this easier to read, it's a little scuffed
-    return await deadline<ElementHandle>(
-      (async () => {
-        while (true) {
-          const result = await this.#celestial.DOM.querySelector({
-            nodeId: this.#id,
-            selector,
-          });
+    try {
+      return await deadline<ElementHandle>(
+        (async () => {
+          while (true) {
+            const result = await this.#celestial.DOM.querySelector({
+              nodeId: this.#id,
+              selector,
+            });
 
-          if (!result) {
-            continue;
+            if (!result.nodeId) {
+              continue;
+            }
+
+            return new ElementHandle(result.nodeId, this.#celestial, this.#page);
           }
-
-          return new ElementHandle(result.nodeId, this.#celestial, this.#page);
-        }
-      })(),
-      this.#page.timeout,
-    );
+        })(),
+        options?.timeout || this.#page.timeout,
+      );
+    } catch {
+      throw new Error("Unable to get element from selector");
+    }
   }
 
   /**

--- a/src/element_handle.ts
+++ b/src/element_handle.ts
@@ -316,11 +316,15 @@ export class ElementHandle {
               selector,
             });
 
-            if (!result.nodeId) {
+            if (!result?.nodeId) {
               continue;
             }
 
-            return new ElementHandle(result.nodeId, this.#celestial, this.#page);
+            return new ElementHandle(
+              result.nodeId,
+              this.#celestial,
+              this.#page,
+            );
           }
         })(),
         options?.timeout || this.#page.timeout,

--- a/src/page.ts
+++ b/src/page.ts
@@ -40,6 +40,10 @@ export type WaitForOptions = {
   waitUntil?: "none" | "load" | "networkidle0" | "networkidle2";
 };
 
+export interface WaitForSelectorOptions {
+  timeout?: number;
+}
+
 export type WaitForNetworkIdleOptions = {
   idleTime?: number;
   idleConnections?: number;
@@ -684,16 +688,16 @@ export class Page extends EventTarget {
   }
 
   /**
-   * Wait for the `selector` to appear in page. If at the moment of calling the method the `selector` already exists, the method will return immediately. If the `selector` doesn't appear after the timeout milliseconds of waiting, the function will throw.
+   * Wait for the `selector` to appear in page. If at the moment of calling the method the `selector` already exists, the method will return immediately. If the `selector` doesn't appear after the timeout milliseconds (10000 by default) of waiting, the function will throw.
    *
    * @example
    * ```ts
    * await page.waitForSelector(".class");
    * ```
    */
-  async waitForSelector(selector: string) {
+  async waitForSelector(selector: string, options?: WaitForSelectorOptions) {
     const root = await this.#getRoot();
-    return root.waitForSelector(selector);
+    return root.waitForSelector(selector, options);
   }
 
   /**

--- a/tests/wait_test.ts
+++ b/tests/wait_test.ts
@@ -18,23 +18,22 @@ Deno.test("Wait for selector", async () => {
   await browser.close();
 });
 
-Deno.test('Fail wait for selector', async () => {
+Deno.test("Fail wait for selector", async () => {
   // Launch browser
   const browser = await launch();
 
   // Open the webpage
-  const page = await browser.newPage('http://deno.land');
+  const page = await browser.newPage("http://deno.land");
 
   await assertRejects(
     () => {
-      return page.waitForSelector('.font-bold1', { timeout: 1000 });
+      return page.waitForSelector(".font-bold1", { timeout: 1000 });
     },
     Error,
     "Unable to get element from selector",
   );
 
   await browser.close();
-
 });
 
 Deno.test("Wait for function", async (t) => {

--- a/tests/wait_test.ts
+++ b/tests/wait_test.ts
@@ -1,4 +1,5 @@
 import { assertSnapshot } from "https://deno.land/std@0.205.0/testing/snapshot.ts";
+import { assertRejects } from "https://deno.land/std@0.215.0/assert/mod.ts";
 
 import { launch } from "../mod.ts";
 
@@ -15,6 +16,25 @@ Deno.test("Wait for selector", async () => {
 
   // Close browser
   await browser.close();
+});
+
+Deno.test('Fail wait for selector', async () => {
+  // Launch browser
+  const browser = await launch();
+
+  // Open the webpage
+  const page = await browser.newPage('http://deno.land');
+
+  await assertRejects(
+    () => {
+      return page.waitForSelector('.font-bold1', { timeout: 1000 });
+    },
+    Error,
+    "Unable to get element from selector",
+  );
+
+  await browser.close();
+
 });
 
 Deno.test("Wait for function", async (t) => {


### PR DESCRIPTION
Currently the `waitForSelector` method does not work as expected, the method **never fails** since the validation of the while loop is not precise (`this.#celestial.DOM.querySelector()` always returns an object even if the node is not found).

<img width="220" alt="image" src="https://github.com/lino-levan/astral/assets/37860819/91c114f1-8fb9-4d56-8f84-dd00cdca14f3">

Therefore, this change suggests a modification in the validation and the implementation of a custom timeout by the user.