### PR TITLE
chore: enhancement $ method to avoid internal errors

### DIFF
--- a/src/element_handle.ts
+++ b/src/element_handle.ts
@@ -94,7 +94,7 @@ export class ElementHandle {
       this.#page.timeout,
     );
 
-    if (result.nodeId === 0) {
+    if (result?.nodeId) {
       return null;
     }
 


### PR DESCRIPTION

There are corner cases where the result is `undefined`, it is proposed to change the validation to avoid internal errors

<img width="876" alt="image" src="https://github.com/lino-levan/astral/assets/37860819/1d5e6705-07de-4ab9-8c13-18926dbc8a4c">

Tests
<img width="337" alt="image" src="https://github.com/lino-levan/astral/assets/37860819/e9703e9b-25fa-4114-bb7e-cd16b4171490">
