### PR TITLE
fix: incorrect event names in `waitForNetworkIdle`

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -634,15 +634,15 @@ export class Page extends EventTarget {
       new Promise<void>((resolve) => {
         const timeoutDone = () => {
           this.#celestial.removeEventListener(
-            "Network_requestWillBeSent",
+            "Network.requestWillBeSent",
             requestStarted,
           );
           this.#celestial.removeEventListener(
-            "Network_loadingFailed",
+            "Network.loadingFailed",
             requestFinished,
           );
           this.#celestial.removeEventListener(
-            "Network_loadingFinished",
+            "Network.loadingFinished",
             requestFinished,
           );
           resolve();


### PR DESCRIPTION
Looks like a typo sneaked into the event names. This meant that we were never removing the event listeners as the event names didn't match which caused timers to leak.

See https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSent