### PR TITLE
feat: support async disposing of `Page` and `Browser`

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -92,6 +92,10 @@ export class Browser {
     this.#options = opts;
   }
 
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+
   /** Returns true if browser is connected remotely instead of using a subprocess */
   get isRemoteConnection(): boolean {
     return !this.#process;

--- a/src/page.ts
+++ b/src/page.ts
@@ -203,6 +203,10 @@ export class Page extends EventTarget {
     this.touchscreen = new Touchscreen(this.#celestial);
   }
 
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close();
+  }
+
   //TODO(@lowlighter): change "query" by "request" https://github.com/denoland/deno/issues/14668
   async #validateRequest({ request }: Fetch_requestPausedEvent["detail"]) {
     const { protocol, host, href } = new URL(request.url);

--- a/tests/resource_test.ts
+++ b/tests/resource_test.ts
@@ -1,0 +1,30 @@
+import { type Browser, launch, type Page } from "../mod.ts";
+import { assertRejects } from "@std/assert/assert-rejects";
+
+Deno.test("Page - close with 'using' keyword", async () => {
+  const browser = await launch();
+  let ref: Page | null = null;
+  {
+    await using page = await browser.newPage();
+    await page.goto("https://example.com");
+    await page.waitForNetworkIdle();
+    ref = page;
+  }
+
+  assertRejects(() => ref.close(), "already been closed");
+
+  await browser.close();
+});
+
+Deno.test("Browser - close with 'using' keyword", async () => {
+  let ref: Browser | null = null;
+  {
+    await using browser = await launch();
+    ref = browser;
+    const page = await browser.newPage();
+    await page.goto("https://example.com");
+    await page.waitForNetworkIdle();
+    await page.close();
+  }
+  assertRejects(() => ref.close(), "already been closed");
+});


### PR DESCRIPTION
Add support for disposing of `Page` and `Browser` instances with the `using` keyword. It's part of https://github.com/tc39/proposal-explicit-resource-management and it's natively supported in Deno. Allows you to write code like this:

```ts
Deno.test("my test", async () => {
   await using browser = await launch();
   await using page = await browser.newPage();
   
   // No need to manually call page.close() and browser.close()
})
```