### PR TITLE
fix: ensure navigation listeners are setup before trigger

### DIFF
--- a/docs/pages/guides/navigation.md
+++ b/docs/pages/guides/navigation.md
@@ -36,8 +36,8 @@ await page.waitForNetworkIdle({ idleConnections: 0, idleTime: 1000 });
 // Click the 'pyro' link
 const xLink = await page.$("a.justify-between:nth-child(1)");
 await Promise.all([
-  xLink!.click(),
   page.waitForNavigation(),
+  xLink!.click(),
 ]);
 
 // Click the link to 'pyro.deno.dev'
@@ -45,8 +45,8 @@ const dLink = await page.$(
   ".markdown-body > p:nth-child(8) > a:nth-child(1)",
 );
 await Promise.all([
-  dLink!.click(),
   page.waitForNavigation(),
+  dLink!.click(),
 ]);
 
 // Close browser

--- a/examples/navigation.ts
+++ b/examples/navigation.ts
@@ -20,8 +20,8 @@ await page.waitForNetworkIdle({ idleConnections: 0, idleTime: 1000 });
 // Click the 'pyro' link
 const xLink = await page.$("a.justify-between:nth-child(1)");
 await Promise.all([
-  xLink!.click(),
   page.waitForNavigation(),
+  xLink!.click(),
 ]);
 
 // Click the link to 'pyro.deno.dev'
@@ -29,8 +29,8 @@ const dLink = await page.$(
   ".markdown-body > p:nth-child(8) > a:nth-child(1)",
 );
 await Promise.all([
-  dLink!.click(),
   page.waitForNavigation(),
+  dLink!.click(),
 ]);
 
 // Close browser

--- a/src/page.ts
+++ b/src/page.ts
@@ -484,11 +484,11 @@ export class Page extends EventTarget {
   async goto(url: string, options?: GoToOptions) {
     options = options ?? {};
     await Promise.all([
+      this.waitForNavigation(options),
       retryDeadline(
         this.#celestial.Page.navigate({ url, ...options }),
         this.timeout,
       ),
-      this.waitForNavigation(options),
     ]);
   }
 
@@ -520,8 +520,8 @@ export class Page extends EventTarget {
    */
   async reload(options?: WaitForOptions) {
     await Promise.all([
-      retryDeadline(this.#celestial.Page.reload({}), this.timeout),
       this.waitForNavigation(options),
+      retryDeadline(this.#celestial.Page.reload({}), this.timeout),
     ]);
   }
 

--- a/tests/wait_test.ts
+++ b/tests/wait_test.ts
@@ -8,10 +8,10 @@ Deno.test("Wait for selector", async () => {
   const browser = await launch();
 
   // Open the webpage
-  const page = await browser.newPage("http://deno.land");
+  const page = await browser.newPage("https://example.com");
 
   // Wait for selector
-  const selected = await page.waitForSelector(".font-bold");
+  const selected = await page.waitForSelector("h1");
   console.log(selected);
 
   // Close browser
@@ -23,7 +23,7 @@ Deno.test("Fail wait for selector", async () => {
   const browser = await launch();
 
   // Open the webpage
-  const page = await browser.newPage("http://deno.land");
+  const page = await browser.newPage("https://example.com");
 
   await assertRejects(
     () => {


### PR DESCRIPTION
Move `waitForNavigation` calls to the top of the  `Promise.all` array to ensure that listeners are set up first before triggering the action. I remember that this was a prominent issue in the early puppeteer days and hopefully that fixes the macOS CI errors.