### PR TITLE
feat: add basic locator API

### DIFF
--- a/src/locator.ts
+++ b/src/locator.ts
@@ -1,0 +1,59 @@
+import { retry } from "@std/async/retry";
+import { deadline } from "@std/async/deadline";
+import type { Page } from "./page.ts";
+import type { ElementHandle } from "./element_handle.ts";
+
+export class Locator<T extends Element> {
+  #page: Page;
+  #selector: string;
+  #timeout: number;
+
+  constructor(
+    page: Page,
+    selector: string,
+    timeout: number,
+  ) {
+    this.#page = page;
+    this.#selector = selector;
+    this.#timeout = timeout;
+  }
+
+  async click() {
+    await retry(async () => {
+      const p = this.#click();
+      await deadline(p, this.#timeout);
+    });
+  }
+
+  async #click() {
+    await this.#page.waitForSelector(this.#selector);
+    const handle = await this.#page.$(this.#selector);
+    if (handle === null) {
+      throw new Error(`Selector "${this.#selector}" not found.`);
+    }
+
+    await handle.click();
+  }
+
+  async wait(): Promise<ElementHandle> {
+    return await this.#page.waitForSelector(this.#selector);
+  }
+
+  async evaluate<R>(fn: (el: T) => R): Promise<R> {
+    return await retry(async () => {
+      const p = this.#evaluate(fn);
+      return await deadline(p, this.#timeout);
+    });
+  }
+
+  async #evaluate<R>(fn: (el: T) => R): Promise<R> {
+    await this.#page.waitForSelector(this.#selector);
+    const handle = await this.#page.$(this.#selector);
+    if (handle === null) {
+      throw new Error(`Selector "${this.#selector}" not found.`);
+    }
+
+    // deno-lint-ignore no-explicit-any
+    return await handle.evaluate(fn, { args: [handle] as any }) as R;
+  }
+}

--- a/src/page.ts
+++ b/src/page.ts
@@ -15,6 +15,7 @@ import { Keyboard } from "./keyboard.ts";
 import { Touchscreen } from "./touchscreen.ts";
 import { Dialog } from "./dialog.ts";
 import { FileChooser } from "./file_chooser.ts";
+import { Locator } from "./locator.ts";
 
 export type DeleteCookieOptions = Omit<
   Parameters<Celestial["Network"]["deleteCookies"]>[0],
@@ -274,6 +275,10 @@ export class Page extends EventTarget {
   async $$(selector: string): Promise<ElementHandle[]> {
     const root = await this.#getRoot();
     return retryDeadline(root.$$(selector), this.timeout);
+  }
+
+  locator<T extends Element = HTMLElement>(selector: string): Locator<T> {
+    return new Locator(this, selector, this.timeout);
   }
 
   /**

--- a/tests/fixtures/counter.html
+++ b/tests/fixtures/counter.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Counter</title>
+  </head>
+  <body>
+    <div class="counter">
+      <output>0</output>
+      <button type="button">increment</button>
+    </div>
+    <script type="module">
+      const btn = document.querySelector("button");
+      const output = document.querySelector("output");
+      btn.addEventListener("click", () => {
+        const num = Number(output.textContent);
+        output.textContent = num + 1;
+      });
+    </script>
+  </body>
+</html>

--- a/tests/fixtures/evaluate.html
+++ b/tests/fixtures/evaluate.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Evaluate</title>
+  </head>
+  <body>
+    <div id="target">hello</div>
+  </body>
+</html>

--- a/tests/fixtures/wait_for_element.html
+++ b/tests/fixtures/wait_for_element.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wait for Element</title>
+  </head>
+  <body>
+    <div id="target"></div>
+    <script type="module">
+      setTimeout(() => {
+        const el = document.createElement("h1");
+        el.textContent = "inserted";
+        document.querySelector("#target").appendChild(el);
+      }, 500);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds a basic locator API. It doesn't have all the additional checks that `puppeteer` has yet as it's based on the existing `Page` methods apart from waiting for the selector.

But that alone makes tests a little simpler to write. And we can always iterate further based on this.

```ts
// before
await (await page.$(".trigger"))!.click();

// after
await page.locator(".trigger").click();
```

```ts
// before
const text = await (await page.$("pre"))!.evaluate(el => el.textContent!);

// after
await page.locator("pre").evaluate(el => el.textContent);
```

Related https://github.com/lino-levan/astral/issues/2