### PR TITLE
fix: print selector on locator failure

### DIFF
--- a/src/element_handle.ts
+++ b/src/element_handle.ts
@@ -345,7 +345,7 @@ export class ElementHandle {
         options?.timeout || this.#page.timeout,
       );
     } catch {
-      throw new Error("Unable to get element from selector");
+      throw new Error(`Unable to get element from selector: ${selector}`);
     }
   }
 


### PR DESCRIPTION
Minor DX improvement: When a `waitForSelector` call fails to find the selector it should include the selector in the error message.