### PR TITLE
fead: add `Browser.disconnect` method

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -117,6 +117,13 @@ export class Browser {
   }
 
   /**
+   * Disconnects the browser from the websocket connection. This is useful if you want to keep the browser running but don't want to use it anymore.
+   */
+  async disconnect() {
+    await this.#celestial.close();
+  }
+
+  /**
    * Closes the browser and all of its pages (if any were opened). The Browser object itself is considered to be disposed and cannot be used anymore.
    */
   async close() {


### PR DESCRIPTION
I was surprised to see that playwright doesn't have this (https://github.com/microsoft/playwright/issues/4956). Looks like we'll have to defer to puppeteer's judgement here.