### PR TITLE
feat: deno v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: download deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
 
       - name: check format
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: download deno
         uses: denoland/setup-deno@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Deno
-        uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@v2
 
       - name: Publish package
         run: deno publish

--- a/docs/pyro.yml
+++ b/docs/pyro.yml
@@ -11,5 +11,5 @@ footer:
   Learn:
     - Introduction /
   Community:
-   - Discord https://discord.gg/XJMMSSC4Fj
-   - Support https://github.com/lino-levan/astral/issues/new
+    - Discord https://discord.gg/XJMMSSC4Fj
+    - Support https://github.com/lino-levan/astral/issues/new

--- a/tests/fixtures/fill.html
+++ b/tests/fixtures/fill.html
@@ -6,6 +6,6 @@
     <title>Fill</title>
   </head>
   <body>
-    <input id="target"></input>
+    <input id="target" />
   </body>
 </html>

--- a/tests/locator_test.ts
+++ b/tests/locator_test.ts
@@ -15,20 +15,14 @@ async function serveFixture(name: string) {
 
   const html = await Deno.readFile(file);
 
-  let address = "";
-  const server = Deno.serve({
-    port: 0,
-    onListen(addr) {
-      address = `http://${addr.hostname}:${addr.port}`;
-    },
-  }, () => {
+  const server = Deno.serve({ port: 0 }, () => {
     return new Response(html, {
       headers: { "Content-Type": "text/html; charset=utf-8" },
     });
   });
 
   return {
-    address,
+    address: `http://localhost:${server.addr.port}`,
     async [Symbol.asyncDispose]() {
       await server.shutdown();
       await server.finished;


### PR DESCRIPTION
### Backgroud

location_test was failing with the following message.

```
 *  Executing task: C:\ProgramData\chocolatey\lib\deno\deno.EXE test --allow-all --no-check --trace-leaks --filter /^Locator - click\(\)$/ d:\Repos\jeiea\2024\09\astral\tests\locator_test.ts 

running 1 test from ./tests/locator_test.ts
Locator - click() ... FAILED (8s)

 ERRORS 

Locator - click() => ./tests/locator_test.ts:39:6
error: RetryError: Retrying exceeded the maxAttempts (5).
        throw new RetryError(error, options.maxAttempts);
              ^
    at retry (https://jsr.io/@std/async/0.223.0/retry.ts:143:15)
    at eventLoopTick (ext:core/01_core.js:175:7)
    at async Locator.click (file:///D:/Repos/jeiea/2024/09/astral/src/locator.ts:24:5)
    at async file:///D:/Repos/jeiea/2024/09/astral/tests/locator_test.ts:46:3
Caused by: Error: Unable to get stable box model to click on
    at ElementHandle.click (file:///D:/Repos/jeiea/2024/09/astral/src/element_handle.ts:192:23)
    at eventLoopTick (ext:core/01_core.js:175:7)
    at async Locator.#click (file:///D:/Repos/jeiea/2024/09/astral/src/locator.ts:37:5)
    at async file:///D:/Repos/jeiea/2024/09/astral/src/locator.ts:26:7
    at async retry (https://jsr.io/@std/async/0.223.0/retry.ts:140:14)
    at async Locator.click (file:///D:/Repos/jeiea/2024/09/astral/src/locator.ts:24:5)
    at async file:///D:/Repos/jeiea/2024/09/astral/tests/locator_test.ts:46:3

 FAILURES 

Locator - click() => ./tests/locator_test.ts:39:6

FAILED | 0 passed | 1 failed | 3 filtered out (8s)

error: Test failed
```

It seems deno 2 changed `Deno.serve()` returns 0.0.0.0 as server address, and windows cannot connect with it.

### Changes

- Use localhost address instead of Deno.serve().addr.
- Change setup-deno action version to v2.

### How to test

- Github workflow should success.