### PR TITLE
fix: print download progress to stderr

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -15,7 +15,7 @@
   },
   "lock": false,
   "imports": {
-    "@deno-library/progress": "jsr:@deno-library/progress@^1.4.9",
+    "@deno-library/progress": "jsr:@deno-library/progress@^1.5.1",
     "@std/assert": "jsr:@std/assert@^1",
     "@std/async": "jsr:@std/async@^1",
     "@std/fs": "jsr:@std/fs@^1",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -137,6 +137,7 @@ async function decompressArchive(source: string, destination: string) {
       total: entries.length,
       clear: true,
       display: ":title :bar :percent",
+      output: Deno.stderr,
     })
     : null;
   let progress = 0;
@@ -157,7 +158,7 @@ async function decompressArchive(source: string, destination: string) {
   }
   await zip.close();
   if (!quiet) {
-    console.log(`\nBrowser saved to ${destination}`);
+    console.error(`\nBrowser saved to ${destination}`);
   }
 }
 
@@ -229,6 +230,7 @@ export async function getBinary(
           total: Number(req.headers.get("Content-Length") ?? 0),
           clear: true,
           display: ":title :bar :percent",
+          output: Deno.stderr,
         });
         let downloaded = 0;
         while (true) {
@@ -241,7 +243,7 @@ export async function getBinary(
           bar.render(downloaded);
         }
         archive.close();
-        console.log(`\nDownload complete (${browser} version ${VERSION})`);
+        console.error(`\nDownload complete (${browser} version ${VERSION})`);
       }
       await decompressArchive(
         resolve(cache, `raw_${VERSION}.zip`),


### PR DESCRIPTION
Close #102

```bash
#!/bin/bash
rm -rf /home/codespace/.cache
echo "STDOUT: $(deno run -A test.ts)"
```
```shell
Downloading chrome 125.0.6400.0                                                    100.00%
Download complete (chrome version 125.0.6400.0)
Inflating /home/codespace/.cache/astral/125.0.6400.0                                         100.00%
Browser saved to /home/codespace/.cache/astral/125.0.6400.0
STDOUT: /home/codespace/.cache/astral/125.0.6400.0/chrome-linux64/chrome