### PR TITLE
add options example

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ console.log(result);
 await browser.close();
 ```
 
+Run basic test scenarios with path and other options.
+
 ```js
+/* basic working example for a UI test with macOS specific path
+ * deno test -A ./page-content-test.js
+ * see also https://docs.deno.com/runtime/fundamentals/testing/
+ * */
 import { launch } from "jsr:@astral/astral";
 import { assert } from "jsr:@std/assert";
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ const text = await page.evaluate(() => {
 	return document.body.querySelector('main h1')?.textContent ?? '';
 });
 
-Deno.test('test page content', async ()=>{
-	assert(text.includes('JavaScript'), 'has JavaScript');
-});
+assert(text.includes('JavaScript'), 'has JavaScript');
 
 await browser.close();
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,31 @@ console.log(result);
 await browser.close();
 ```
 
+```js
+import { launch } from "jsr:@astral/astral";
+import { assert } from "jsr:@std/assert";
+
+const browser = await launch({
+  // macOS specific path option
+  path: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  args: ['--remote-debugging-port=9222', '--headless=new', '--no-first-run', '--password-store=basic', '--use-mock-keychain', '--hide-scrollbars', '--no-sandbox']
+});
+
+const page = await browser.newPage("https://deno.com");
+
+// Run code in the context of the browser
+const text = await page.evaluate(() => {
+	return document.body.querySelector('main h1')?.textContent ?? '';
+});
+
+Deno.test('test page content', async ()=>{
+	assert(text.includes('JavaScript'), 'has JavaScript');
+});
+
+await browser.close();
+
+```
+
 You can navigate to a page and interact with it.
 
 ```ts

--- a/examples/page-content-test.js
+++ b/examples/page-content-test.js
@@ -18,8 +18,6 @@ const text = await page.evaluate(() => {
   return document.body.querySelector('main h1')?.textContent ?? '';
 });
 
-Deno.test('test page content', async ()=>{
-  assert(text.includes('JavaScript'), 'has JavaScript');
-});
+assert(text.includes('JavaScript'), 'has JavaScript');
 
 await browser.close();

--- a/examples/page-content-test.js
+++ b/examples/page-content-test.js
@@ -1,0 +1,25 @@
+/* basic working example for a UI test with macOS specific path
+ * deno test -A ./page-content-test.js
+ * see also https://docs.deno.com/runtime/fundamentals/testing/
+ * */
+import { launch } from "jsr:@astral/astral";
+import { assert } from "jsr:@std/assert";
+
+const browser = await launch({
+  // macOS specific path option
+  path: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  args: ['--remote-debugging-port=9222', '--headless=new', '--no-first-run', '--password-store=basic', '--use-mock-keychain', '--hide-scrollbars', '--no-sandbox']
+});
+
+const page = await browser.newPage("https://deno.com");
+
+// Run code in the context of the browser
+const text = await page.evaluate(() => {
+  return document.body.querySelector('main h1')?.textContent ?? '';
+});
+
+Deno.test('test page content', async ()=>{
+  assert(text.includes('JavaScript'), 'has JavaScript');
+});
+
+await browser.close();


### PR DESCRIPTION
add example of basic page test scenario with working `path` and `args` options to fix #107 