### PR TITLE
Refactor launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ const browser = await launch();
 
 // Connect to first browser instead
 const anotherBrowser = await launch({ wsEndpoint: browser.wsEndpoint() });
+// or simply...
+const anotherBrowser2 = await launch(browser.wsEndpoint());
+
 ```
 
 ## BYOB - Bring Your Own Browser
@@ -161,10 +164,7 @@ connecting to it is as simple as
 import { launch } from "jsr:@astral/astral";
 
 // Connect to remote endpoint
-const browser = await launch({
-  wsEndpoint: "<WS-ENDPOINT>",
-  headless: false,
-});
+const browser = await launch("localhost:1337");
 
 console.log(browser.wsEndpoint());
 


### PR DESCRIPTION
Now you can use "launch" to connect to an existing browser by passing either an `http://` or a `ws://` string
I've also implemented the old way of doing that as a legacy option - old code will be recognised as wrong by typescript, but it will not break, with a negligible impact on the codebase and on performance