### PR TITLE
feat: add native coverage collection support

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -4,6 +4,7 @@ import { deadline } from "@std/async/deadline";
 import { Celestial, PROTOCOL_VERSION } from "../bindings/celestial.ts";
 import { getBinary } from "./cache.ts";
 import {
+  type CoverageOptions,
   Page,
   type SandboxOptions,
   type UserAgentOptions,
@@ -162,7 +163,11 @@ export class Browser implements AsyncDisposable {
    */
   async newPage(
     url?: string,
-    options?: WaitForOptions & SandboxOptions & UserAgentOptions,
+    options?:
+      & WaitForOptions
+      & SandboxOptions
+      & UserAgentOptions
+      & CoverageOptions,
   ): Promise<Page> {
     const { targetId } = await this.#celestial.Target.createTarget({
       url: "",
@@ -173,8 +178,11 @@ export class Browser implements AsyncDisposable {
     const websocket = new WebSocket(wsUrl);
     await websocketReady(websocket);
 
-    const { waitUntil, sandbox } = options ?? {};
-    const page = new Page(targetId, url, websocket, this, { sandbox });
+    const { waitUntil, sandbox, coverageDir } = options ?? {};
+    const page = new Page(targetId, url, websocket, this, {
+      sandbox,
+      coverageDir,
+    });
     this.pages.push(page);
 
     const celestial = page.unsafelyGetCelestialBindings();
@@ -191,6 +199,7 @@ export class Browser implements AsyncDisposable {
       celestial.Runtime.enable(),
       celestial.Network.enable({}),
       celestial.Page.setInterceptFileChooserDialog({ enabled: true }),
+      coverageDir ? celestial.Profiler.enable() : null,
       sandbox ? celestial.Fetch.enable({}) : null,
     ]);
 

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,5 +1,8 @@
 import { deadline } from "@std/async/deadline";
 import { fromFileUrl } from "@std/path/from-file-url";
+import { toFileUrl } from "@std/path/to-file-url";
+import { join } from "@std/path/join";
+import { ensureDir } from "@std/fs/ensure-dir";
 
 import type {
   Fetch_requestPausedEvent,
@@ -65,6 +68,19 @@ export type WaitForNetworkIdleOptions = {
 /** The options for sandboxing */
 export type SandboxOptions = {
   sandbox?: boolean;
+};
+
+/** The options for coverage */
+export type CoverageOptions = {
+  coverageDir?: string;
+};
+
+/** V8 CallSite (subset). */
+type CallSite = {
+  getFileName: () => string;
+  getFunctionName: () => string | null;
+  getLineNumber: () => number;
+  getColumnNumber: () => number;
 };
 
 /** The options for user agents */
@@ -140,6 +156,7 @@ export class Page extends EventTarget implements AsyncDisposable {
   #celestial: Celestial;
   #browser: Browser;
   #url: string;
+  #coverageDir?: string;
 
   readonly timeout = 10000;
   readonly mouse: Mouse;
@@ -151,7 +168,7 @@ export class Page extends EventTarget implements AsyncDisposable {
     url: string | undefined,
     ws: WebSocket,
     browser: Browser,
-    options: SandboxOptions,
+    options: SandboxOptions & CoverageOptions,
   ) {
     super();
 
@@ -159,6 +176,7 @@ export class Page extends EventTarget implements AsyncDisposable {
     this.#url = url ?? "about:blank";
     this.#celestial = new Celestial(ws);
     this.#browser = browser;
+    this.#coverageDir = options?.coverageDir;
 
     this.#celestial.addEventListener("Page.frameNavigated", (e) => {
       const { frame } = e.detail;
@@ -526,12 +544,23 @@ export class Page extends EventTarget implements AsyncDisposable {
     func: EvaluateFunction<T, R>,
     evaluateOptions?: EvaluateOptions<R>,
   ): Promise<T> {
+    let coverage = false;
     if (typeof func === "function") {
+      coverage = !!this.#coverageDir;
       const args = evaluateOptions?.args ?? [];
       func = `(${func.toString()})(${
         args.map((arg) => `${JSON.stringify(arg)}`).join(",")
       })`;
     }
+
+    if (coverage && (this.#coverageDir)) {
+      await this.#celestial.Profiler.startPreciseCoverage({
+        callCount: true,
+        detailed: true,
+        allowTriggeredUpdates: false,
+      });
+    }
+
     const { result, exceptionDetails } = await retryDeadline(
       this.#celestial.Runtime.evaluate({
         expression: func,
@@ -540,6 +569,36 @@ export class Page extends EventTarget implements AsyncDisposable {
       }),
       this.timeout,
     );
+
+    if (coverage && (this.#coverageDir)) {
+      const { result: [coverage] } = await this.#celestial.Profiler
+        .takePreciseCoverage();
+      await this.#celestial.Profiler.stopPreciseCoverage();
+
+      const caller = this.#getCaller();
+      const source = await Deno.readTextFile(caller.filename);
+      const offset =
+        source.replace(source.split("\n").slice(caller.line).join("\n"), "")
+          .slice(caller.column).length;
+      coverage.url = caller.url;
+
+      coverage.functions.forEach(({ ranges }) =>
+        ranges.forEach((range) => {
+          range.startOffset += offset;
+          range.endOffset += offset;
+        })
+      );
+      await ensureDir(this.#coverageDir);
+      console.log("caller:", caller);
+      console.log("coverage report:", coverage);
+      console.log("computed offset:", offset);
+      console.log("source mapping (attempt):", source.slice(offset));
+
+      await Deno.writeTextFile(
+        join(this.#coverageDir, "coverage-test.json"), // `${crypto.randomUUID()}.json`
+        JSON.stringify(coverage, null, 2),
+      );
+    }
 
     if (exceptionDetails) {
       throw exceptionDetails;
@@ -559,6 +618,31 @@ export class Page extends EventTarget implements AsyncDisposable {
     }
 
     return result.value;
+  }
+
+  #getCaller() {
+    const Trace = Error as unknown as {
+      prepareStackTrace: (error: Error, stack: CallSite[]) => unknown;
+    };
+    const _ = Trace.prepareStackTrace;
+    Trace.prepareStackTrace = (_, stack) => stack;
+    const { stack } = new Error();
+    Trace.prepareStackTrace = _;
+    const callers = (stack as unknown as CallSite[])
+      .map((callsite) => ({
+        filename: callsite.getFileName(),
+        line: callsite.getLineNumber() - 1,
+        column: callsite.getColumnNumber() - 1,
+      }))
+      .filter((callsite) =>
+        !callsite.filename.startsWith("ext:") &&
+        callsite.filename !== import.meta.filename
+      )
+      .map((callsite) => ({
+        ...callsite,
+        url: toFileUrl(callsite.filename).href,
+      }));
+    return callers[0];
   }
 
   /**

--- a/tests/coverage.ts
+++ b/tests/coverage.ts
@@ -1,0 +1,11 @@
+import { launch } from "../mod.ts";
+
+await using browser = await launch();
+await using page = await browser.newPage("http://example.com", {
+  coverageDir: Deno.env.get("DENO_COVERAGE_DIR"),
+});
+
+await page.evaluate(() => {
+  console.log("foo");
+  console.log("bar");
+});

--- a/tests/coverage_test.ts
+++ b/tests/coverage_test.ts
@@ -1,0 +1,1 @@
+import "./coverage.ts";


### PR DESCRIPTION
Towards #13
Iterating upon https://github.com/lino-levan/astral/issues/13#issuecomment-1778200641

*Note: this is more of a proof of concept for now, though it could helps others see how to collect browser coverage with astral, but ideally it'd be nice to have a "native" integration with the deno ecosystem*

Thanks to @kt3k with their work on https://github.com/denoland/deno/pull/28291, we'll be able to directly write coverage in the same one as deno 

In this pr state, if `DENO_COVERAGE_DIR` is set it'd assume you want to collect coverage

If you run this for example
```ts
// coverage.ts
// ...
await page.evaluate(() => {
  console.log("foo");
  console.log("bar");
});
```

You'll get the following outputs:
![image](https://github.com/user-attachments/assets/e1429ac4-53be-431f-ac3e-0855011fab03)

As you can see, by using clever hacks on `Error.prepareStacktrace` from the V8 internals, we're able to map back from which file you executed the `page.evaluate()` and patch back the coverage result with the "real" url, and ideally you'll offset all the range using lines+col numbers to map back to original file (since they're relative to the browser context)

The last part prints where the expression was invoked by `evaluate()`

In the current state it somewhat works:
![image](https://github.com/user-attachments/assets/d0c37dbc-d27e-4a58-842b-8bad3df1ac06)

As you can see line 9 has been covered (but 10 should be too)
The end goal is that when you do `deno test --coverage` you get everything covered, including functions called in the astral context (my dream)

But now I need some guidance because I'm not an expert on how the coverage files exactly works. 
From my understanding:
- deno will only consider the first occurence of a coverage file if multiple files has same url (it won't merge them)
  - this currently render this feature useless, but one could pass another `DENO_COVERAGE_DIR` and do the patching manually
- i'm not sure whether the offset are describing bytes or number of characters
- the offset I retrieve is currently errored by a few bytes, because the caller maps back to `await page.evaluate(` and not the actual function inside it (because we trace the `evaluate()` call, we're not actually calling the given expression)
  - I tried doing some string matching with `func.toString()` but there is an implicit formatting when calling this sub, so the result may not match (and it'd be too hacky anyway)
- *limitation:* you need to use an anonymous function for this to work, if you use an alias (like an imported function) we're not able to follow the typescript reference (unless we'd parse the typescript but we don't want to do that)
- *limitation:* similarly, if you pass a string expression, you cannot cover it (but currently it's a clever hack to not drop your coverage stats 🙃)

Some thoughts about this @lino-levan ?