### PR TITLE
feat(sandbox): granular permissions

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -14,6 +14,7 @@
     "jsxImportSource": "https://esm.sh/preact@10.16.0"
   },
   "lock": false,
+  "unstable": ["worker-options"],
   "imports": {
     "@deno-library/progress": "jsr:@deno-library/progress@^1.5.1",
     "@std/assert": "jsr:@std/assert@^1",

--- a/docs/pages/advanced/sandbox.md
+++ b/docs/pages/advanced/sandbox.md
@@ -40,3 +40,35 @@ const browser = await launch();
 // Close browser
 await browser.close();
 ```
+
+## Using permissions subsets
+
+By default, using `sandbox: true` will inherit all permissions from current
+thread.
+
+You can choose to pass a
+[`Deno.PermissionOptionsObject`](https://docs.deno.com/api/deno/~/Deno.PermissionOptionsObject)
+to use a subset of these permissions instead and further restrict what a given
+page can access.
+
+Currently both
+[`Deno.ReadPermissionDescriptor`](https://docs.deno.com/api/deno/~/Deno.ReadPermissionDescriptor)
+and
+[`Deno.NetPermissionDescriptor`](https://docs.deno.com/api/deno/~/Deno.NetPermissionDescriptor)
+are supported.
+
+Using `true` (e.g. `net: true` / `read: true`) is the same as using `"inherit"`
+and will not throw any permission escalation error.
+
+```ts
+await using browser = await launch();
+await using page = await browser.newPage("https://example.com", {
+  sandbox: { permissions: { net: ["example.com"] } },
+});
+```
+
+Under the hood, this option spawns a self-closing `Worker` with the given
+permissions subset and validates permissions from within the restricted thread,
+meaning that this feature actually use Deno's own permission system.
+
+Using permissions subsets requires the `--unstable-worker-options` flag.

--- a/src/page.ts
+++ b/src/page.ts
@@ -290,7 +290,9 @@ export class Page extends EventTarget implements AsyncDisposable {
     }
     if (
       (permissions === "inherit") ||
-      (permissions[descriptor.name] === "inherit")
+      (permissions[descriptor.name] === "inherit") ||
+      (permissions[descriptor.name] === true) ||
+      (permissions[descriptor.name] === undefined)
     ) {
       const { state } = await Deno.permissions.request(descriptor);
       return state;


### PR DESCRIPTION
Towards #116

This PR adds the possibility to restrict page permissions using a subset of the current permissions using the `sandbox` option, rather than inheriting all permissions

```ts
const sandbox = { permissions: { net: ["example.com"] } }
await using browser = await launch();
await using page = await browser.newPage("https://example.com", { sandbox });
```