### PR TITLE
feat(browser): improve bin args support

### DIFF
--- a/src/bin_args.ts
+++ b/src/bin_args.ts
@@ -1,0 +1,130 @@
+import type { BrowserOptions, LaunchOptions } from "./browser.ts";
+
+/**
+ * Generates a list of browser switches according to specified product,
+ * environement, and `quickConfig` params.
+ *
+ * It also adds switches specified in `ASTRAL_BIN_ARGS` environment variable
+ * if permission is granted.
+ *
+ * References for chromium flags:
+ * - https://peter.sh/experiments/chromium-command-line-switches/
+ */
+export function generateBinArgs(
+  product: NonNullable<BrowserOptions["product"]>,
+  { quickConfig, args = [], headless = true }: {
+    quickConfig?: LaunchOptions["quickConfig"];
+    args?: string[];
+    headless?: boolean;
+  },
+) {
+  const binArgs = [
+    "--remote-debugging-port=0",
+    "--no-first-run",
+    "--password-store=basic",
+    "--use-mock-keychain",
+  ];
+
+  if (product === "chrome") {
+    binArgs.push("--disable-blink-features=AutomationControlled");
+  }
+  if (headless) {
+    binArgs.push(
+      product === "chrome" ? "--headless=new" : "--headless",
+      "--hide-scrollbars",
+    );
+  }
+
+  if (quickConfig?.windowSize) {
+    binArgs.push(
+      `--window-size=${quickConfig.windowSize.width},${quickConfig.windowSize.height}`,
+    );
+  }
+
+  if ((product === "chrome") && (quickConfig?.hardened)) {
+    binArgs.push(
+      // Skip additional first run tasks
+      "--disable-first-run-ui",
+      // Prevent the service process from adding itself as an autorun process
+      "--no-service-autorun",
+      // Disable default browser and search engine checks
+      "--no-default-browser-check",
+      "--disable-search-engine-choice-screen",
+      // Disable account syncing features
+      "--disable-sync",
+      // Bypass user interactions for some features
+      "--no-user-gesture-required",
+      "--allow-pre-commit-input",
+      "--deny-permission-prompts",
+      "--disable-popup-blocking",
+      "--disable-prompt-on-repost",
+      "--disable-input-event-activation-protection",
+      // Disable plugins, extensions, and defaults apps
+      "--disable-plugins",
+      "--disable-extensions",
+      "--disable-default-apps",
+      "--disable-component-update",
+      "--disable-component-extensions-with-background-pages",
+      // Disable telemetry
+      "--incognito",
+      "--no-pings",
+      "--disable-stack-profiler",
+      "--disable-field-trial-config",
+      "--disable-domain-reliability",
+      "--disable-logging",
+      "--metrics-recording-only",
+      // Disable crash reports
+      "--noerrdialogs",
+      "--hide-crash-restore-bubble",
+      "--disable-crash-reporter",
+      "--disable-breakpad",
+      "--disable-auto-reload",
+      // Performances and caching
+      "--aggressive-cache-discard",
+      "--disable-back-forward-cache",
+      "--disable-background-networking",
+      "--disable-background-timer-throttling",
+      "--disable-backgrounding-occluded-windows",
+      "--disable-hang-monitor",
+      "--disable-ipc-flooding-protection",
+      // Rendering
+      "--force-color-profile=srgb",
+      "--disable-renderer-backgrounding",
+      "--disable-software-rasterizer",
+      "--disable-gpu",
+      "--disable-accelerated-2d-canvas",
+      // Disable extras APIs
+      "--no-experiments",
+      "--mute-audio",
+      "--disable-dinosaur-easter-egg",
+      "--disable-translate",
+      "--disable-virtual-keyboard",
+      "--disable-touch-drag-drop",
+      "--disable-volume-adjust-sound",
+      "--disable-audio-input",
+      "--disable-audio-output",
+      "--disable-notifications",
+      "--disable-file-system",
+      "--disable-speech-api",
+      "--disable-speech-synthesis-api",
+      "--disable-remote-playback-api",
+      "--disable-presentation-api",
+      "--disable-shared-workers",
+      "--disable-features=AcceptCHFrame,Translate,BackForwardCache,MediaRouter,OptimizationHints,DialMediaRouteProvider",
+    );
+  }
+
+  if ((product === "chrome") && (quickConfig?.bgTransparent)) {
+    binArgs.push("--default-background-color=00000000");
+  }
+
+  const envArgs = Deno.permissions.querySync({
+    name: "env",
+    variable: "ASTRAL_BIN_ARGS",
+  });
+  if ((envArgs.state === "granted") && (Deno.env.has("ASTRAL_BIN_ARGS"))) {
+    binArgs.push(...Deno.env.get("ASTRAL_BIN_ARGS")!);
+  }
+
+  return [...new Set([...binArgs, ...args])];
+}

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -11,6 +11,7 @@ import {
 } from "./page.ts";
 import { WEBSOCKET_ENDPOINT_REGEX, websocketReady } from "./util.ts";
 import { DEBUG } from "./debug.ts";
+import { generateBinArgs } from "./bin_args.ts";
 
 async function runCommand(
   command: Deno.Command,
@@ -260,6 +261,11 @@ export type LaunchOptions = BrowserOptions & {
   path?: string;
   args?: string[];
   cache?: string;
+  quickConfig?: {
+    hardened?: boolean;
+    bgTransparent?: boolean;
+    windowSize?: { width: number; height: number };
+  };
 };
 
 export type ConnectOptions = BrowserOptions & {
@@ -290,6 +296,7 @@ export async function launch(opts?: LaunchOptions): Promise<Browser> {
   const product = opts?.product ?? "chrome";
   const args = opts?.args ?? [];
   const cache = opts?.cache;
+  const quickConfig = opts?.quickConfig;
   let path = opts?.path;
 
   const options: BrowserOptions = {
@@ -307,23 +314,7 @@ export async function launch(opts?: LaunchOptions): Promise<Browser> {
   }
 
   // Launch child process
-  const binArgs = [
-    "--remote-debugging-port=0",
-    "--no-first-run",
-    "--password-store=basic",
-    "--use-mock-keychain",
-    ...(product === "chrome"
-      ? ["--disable-blink-features=AutomationControlled"]
-      : []),
-    // "--no-startup-window",
-    ...(headless
-      ? [
-        product === "chrome" ? "--headless=new" : "--headless",
-        "--hide-scrollbars",
-      ]
-      : []),
-    ...args,
-  ];
+  const binArgs = generateBinArgs(product, { quickConfig, args, headless });
 
   if (DEBUG) {
     console.log(`Launching: ${path} ${binArgs.join(" ")}`);

--- a/tests/navigation_test.ts
+++ b/tests/navigation_test.ts
@@ -13,3 +13,16 @@ Deno.test("Page - back and forth navigation works", async () => {
   await page.close();
   await browser.close();
 });
+
+Deno.test("Page - back and forth navigation works (hardened browser)", async () => {
+  const browser = await launch({ quickConfig: { hardened: true } });
+  const page = await browser.newPage();
+  await page.goto("https://example.com");
+  await page.locator("a").click();
+  await page.goBack();
+  assertRejects(() => page.goBack(), "No history entry available");
+  await page.goForward();
+  assertRejects(() => page.goForward(), "No history entry available");
+  await page.close();
+  await browser.close();
+});


### PR DESCRIPTION
Close #159
Related #153

This PR add a new `quickConfig` option in the `LaunchOptions`, with the following sub-options:
- `hardened`, if set on chrome, it toggles additional switches to turn off telemetry, "unusual" features/apis, etc.
- `bgTransparent`, if set add the switch that makes the default background transparent
- `windowSize`, if set add the switch that configures the initial window size 

Additionally, this adds a new `ASTRAL_BIN_ARGS` environement variable, which can be used to set additional flags directly from the environment (useful for containairization)

```dockerfile
# Example: Dockerfile
ENV ASTRAL_BIN_ARGS="--no-sandbox --disable-dev-shm-usage"
```