### PR TITLE
feat(page.evaluate): support more complex return types

### DIFF
--- a/src/page.ts
+++ b/src/page.ts
@@ -712,9 +712,9 @@ export class Page extends EventTarget implements AsyncDisposable {
           propResult.map((res) => res.value!.value),
         );
       }
-      async function parseDeepSerializedValue(
+      const parseDeepSerializedValue = async (
         deepSerializedValue: Runtime_DeepSerializedValue,
-      ) {
+      ) => {
         if (
           deepSerializedValue.type === "string" ||
           deepSerializedValue.type === "boolean" ||
@@ -732,7 +732,7 @@ export class Page extends EventTarget implements AsyncDisposable {
             deepSerializedValue.value.map(parseDeepSerializedValue),
           );
         } else if (deepSerializedValue.type === "object") {
-          const obj: Record<string, any> = {};
+          const obj: Record<string, unknown> = {};
           for (const [key, val] of deepSerializedValue.value) {
             obj[key] = await parseDeepSerializedValue(val);
           }
@@ -740,10 +740,12 @@ export class Page extends EventTarget implements AsyncDisposable {
         }
         throw new Error(
           `Encountered unserializable value ${
-            JSON.stringify(deepSerializedValue)
+            JSON.stringify(
+              deepSerializedValue,
+            )
           }. Please file an issue for Astral.`,
         );
-      }
+      };
 
       // @ts-ignore Only returns this value if T does
       return await parseDeepSerializedValue(result.deepSerializedValue);

--- a/tests/evaluate_test.ts
+++ b/tests/evaluate_test.ts
@@ -45,7 +45,7 @@ Deno.test("Testing evaluate", async (t) => {
 
 Deno.test(
   "Testing evaluate with primative / simple object values",
-  async (t) => {
+  async () => {
     // Launch browser
     await using browser = await launch();
 
@@ -113,7 +113,7 @@ Deno.test(
   },
 );
 
-Deno.test("Testing evaluate with top-level typedarray", async (t) => {
+Deno.test("Testing evaluate with top-level typedarray", async () => {
   // Launch browser
   await using browser = await launch();
 


### PR DESCRIPTION
Adds support for bigints in objects and top-level typedarrays (slowly)