### PR TITLE
fix: Take page scroll into account in ElementHandle.screenshot()

### DIFF
--- a/src/element_handle.ts
+++ b/src/element_handle.ts
@@ -293,11 +293,13 @@ export class ElementHandle {
       );
     }
 
+    const { cssLayoutViewport } = await this.#celestial.Page.getLayoutMetrics();
+
     return await this.#page.screenshot({
       ...opts,
       clip: {
-        x: boxModel.border[0].x,
-        y: boxModel.border[0].y,
+        x: boxModel.border[0].x + cssLayoutViewport.pageX,
+        y: boxModel.border[0].y + cssLayoutViewport.pageY,
         width: boxModel.border[2].x - boxModel.border[0].x,
         height: boxModel.border[2].y - boxModel.border[0].y,
         scale: opts?.scale ?? 1,


### PR DESCRIPTION
I've found that the clipping in ElementHandle.screenshot() is incorrect if the page has been scrolled, including if it was scrolled to make the element visible for the screenshot.

The co-ordinates in the element's box model are changed after scrolling, but the screenshot clip argument needs the original values.