### PR TITLE
feat: add new presets for contenairized and lambda environments

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -275,6 +275,8 @@ export type LaunchOptions = BrowserOptions & {
   cache?: string;
   launchPresets?: {
     hardened?: boolean;
+    containerized?: boolean;
+    lambdaInstance?: boolean;
     bgTransparent?: boolean;
     windowSize?: { width: number; height: number };
   };
@@ -320,7 +322,10 @@ export async function launch(opts?: LaunchOptions): Promise<Browser> {
     path = await getBinary(product, { cache });
   }
 
-  if (!args.find((arg) => arg.startsWith("--user-data-dir="))) {
+  if (
+    (!args.find((arg) => arg.startsWith("--user-data-dir="))) &&
+    (!launchPresets?.lambdaInstance)
+  ) {
     const tempDir = Deno.makeTempDirSync();
     args.push(`--user-data-dir=${tempDir}`);
   }

--- a/tests/bin_args_test.ts
+++ b/tests/bin_args_test.ts
@@ -69,3 +69,23 @@ Deno.test("Bin args for hardened chrome", () => {
     /--no-experiments/,
   );
 });
+
+Deno.test("Bin args for containerized chrome", () => {
+  assertNotMatch(generateBinArgs("chrome", {}).join(" "), /--no-sandbox/);
+  assertMatch(
+    generateBinArgs("chrome", { launchPresets: { containerized: true } }).join(
+      " ",
+    ),
+    /--no-sandbox/,
+  );
+});
+
+Deno.test("Bin args for lambda chrome", () => {
+  assertNotMatch(generateBinArgs("chrome", {}).join(" "), /--single-process/);
+  assertMatch(
+    generateBinArgs("chrome", { launchPresets: { lambdaInstance: true } }).join(
+      " ",
+    ),
+    /--single-process/,
+  );
+});


### PR DESCRIPTION
This PR adds two new presets:
- `containerized`: for containers images (e.g. Docker)
- `lambdaInstance`: for AWS lamda-like environements (e.g. Vercel).

The former is just a convenience alias, since chromium sandboxing must almost always be disabled with docker.
Maybe we could also default `--user-data-dir=/tmp` too with this preset.

The latter might interest a lot of people (and might be worth being documented in a future iteration) and offers the flags required to launch chromium on AWS lambda-like environements, such as serverless services like Vercel.

The following link shows a proof of concept of using deno + astral + chrome + vercel: 
https://vercel-deno-runtime.vercel.app/#lambda_chromium.ts  

There is however a small subtility though. 
These environement are resources tight so you need to use a trimmed down version of chromium (like [`Sparticuz/chromium`](https://github.com/Sparticuz/chromium), which is a fork of the unmaintained [`alixaxel/chrome-aws-lambda`](https://github.com/alixaxel/chrome-aws-lambda)) that has been compiled specifically for it, in addition to add extra optimizations flags to make it faster.

It means that you cannot use the astral downloader for it, so I created a small tool for it [`jsr:@libs/toolbox/download-lambda-chromium`](https://github.com/lowlighter/libs/blob/main/toolbox/download_lambda_chromium.ts) but it might be nice to integrate it directly to `@astral` scope. The only thing is that it's a third-party maintaining the upstream recompiled version.

The flags are mostly taken from:
https://github.com/Sparticuz/chromium/blob/dd57f035695c6773e17768176bda1910b1e39287/source/index.ts#L33-L89